### PR TITLE
Add support for MojoConsole

### DIFF
--- a/GC-Command-Helper/API/CommandApi.cs
+++ b/GC-Command-Helper/API/CommandApi.cs
@@ -153,4 +153,66 @@ namespace GC_Command_Helper.API
 
         }
     }
+
+    public static class MojoApi
+    {
+        public static Request request { get; set; }
+
+        public static string api { get; set; }
+
+        public static string token { get; set; }
+
+        public class ReqDT
+        {
+            public String k2 = "";
+            public String request = "";
+            public Object payload = null;
+        }
+
+        public class RespDT
+        {
+            public int code = 200;
+            public String message = "success";
+            public Object payload;
+        }
+
+        public static void EnsureInit()
+        {
+            if (request == null)
+            {
+                request = new Request();
+
+            }
+            if (api == null)
+            {
+                api = $"https://127.0.0.1/mojoplus/api";
+            }
+
+        }
+
+        public static async Task<RespDT> Command(string command)
+        {
+            EnsureInit();
+            var reqdt = new ReqDT
+            {
+                request = "invoke",
+                payload = command.Substring(1),
+                k2 = token
+            };
+
+            var r = await request.PostJson(api, JsonConvert.SerializeObject(reqdt));
+            RespDT resp;
+            try
+            {
+                resp = JsonConvert.DeserializeObject<RespDT>(r);
+            }
+            catch
+            {
+                resp = new RespDT();
+            }
+            return resp;
+
+        }
+    }
+
 }

--- a/GC-Command-Helper/App.xaml
+++ b/GC-Command-Helper/App.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:GC_Command_Helper"
-             StartupUri="MainWindow.xaml">
+             Startup="Application_Startup">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/GC-Command-Helper/App.xaml.cs
+++ b/GC-Command-Helper/App.xaml.cs
@@ -5,6 +5,7 @@ using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
+using Newtonsoft.Json;
 
 namespace GC_Command_Helper
 {
@@ -13,5 +14,27 @@ namespace GC_Command_Helper
     /// </summary>
     public partial class App : Application
     {
+        private class MojoParam
+        {
+            public string d = "";
+            public string k2 = "";
+        }
+        private void Application_Startup(object sender, StartupEventArgs e)
+        {
+            MainWindow wnd = new MainWindow();
+            if (e.Args.Length == 1)
+            { 
+                Uri arg_url;
+                var arg = Uri.TryCreate(e.Args[0],UriKind.Absolute, out arg_url);
+                GlobalProps.MojoServer = arg_url.GetComponents(UriComponents.Fragment, UriFormat.Unescaped);
+                MojoParam mp = JsonConvert.DeserializeObject<MojoParam>(GlobalProps.MojoServer);
+                API.MojoApi.token = mp.k2;
+                API.MojoApi.api = mp.d + "/mojoplus/api";
+            }
+                
+            wnd.Show();
+        }
     }
+
+
 }

--- a/GC-Command-Helper/GlobalProps.cs
+++ b/GC-Command-Helper/GlobalProps.cs
@@ -13,7 +13,7 @@ namespace GC_Command_Helper
 
         public static setCMD SetCMD;
 
-
+        public static string MojoServer;
         public class SimpleItem
         {
             public string Name { get; set; }


### PR DESCRIPTION
* Register self as a URL handler for schema `gccomh://`
* Parse the command line arguments as mojoconsole parameter
* Add a helper for send request to mojoconsole

-----

添加MojoConsole作为后端的支持

* 将自己注册为打开程序，处理schema为`gccomh://`类型的请求
* 从命令行参数中读取并处理mojoconsole的连接参数
* 实现与mojoconsole后端的连接

后续开发计划：mojoconsole将在游戏内尝试向client发送如`gccomh://placeholder#%7B%22k2%22%3A%20%2210001%3A1652957071%3A5911b8b64ab6b62cc43630d90159f64fe2a6635ea1112bc59de77e15546f3e17%22%2C%22d%22%3A%20%22https%3A//10.0.0.188%22%7D` 类型的URL，客户端点击链接后会直接打开GC-Command-Helper。GC-Command-Helper从命令行接受参数后即可直接与grasscutter服务器的mojoconsole后端进行连接。